### PR TITLE
Fix Full Block Checks

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/data/LightDataAccess.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/model/light/data/LightDataAccess.java
@@ -70,7 +70,7 @@ public abstract class LightDataAccess {
         }
 
         boolean op = !block.hasTransparency() || block.getOpacity() == 0;
-        boolean fo = block.hasTransparency();
+        boolean fo = block.isFullBlock();
         boolean fc = block.renderAsNormalBlock();
 
         // OPTIMIZE: Do not calculate lightmap data if the block is full and opaque.

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -165,8 +165,7 @@ public class RenderSectionManager {
         final boolean useOcclusionCulling;
         BlockPos origin = CameraUtils.getBlockPosition();
 
-        if (spectator &&
-                !this.level.getBlockState(origin).getBlock().hasTransparency()) {
+        if (spectator && this.level.getBlockState(origin).getBlock().isFullBlock()) {
             useOcclusionCulling = false;
         } else {
             useOcclusionCulling = SodiumClientMod.options().performance.smartCull;

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/compile/tasks/ChunkBuilderMeshingTask.java
@@ -130,7 +130,7 @@ public class ChunkBuilderMeshingTask extends ChunkBuilderTask<ChunkBuildOutput> 
                             }
                         }
 
-                        if (blockState.getBlock().hasTransparency()) {
+                        if (blockState.getBlock().isFullBlock()) {
                             occluder.markClosed(blockPos);
                         }
                     }

--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/shader/DefaultShaderInterface.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/render/chunk/shader/DefaultShaderInterface.java
@@ -52,7 +52,7 @@ public class DefaultShaderInterface implements ChunkShaderInterface {
 
     @Deprecated(forRemoval = true) // should be handled properly in GFX instead.
     private void bindTexture(ChunkShaderTextureSlot slot, int textureId) {
-        GlStateManager.activeTexture(textureId);
+        GlStateManager.activeTexture(textureId); // this shouldn't be needed?
 
         var uniform = this.uniformTextures.get(slot);
         uniform.setInt(textureId);


### PR DESCRIPTION
Block#hasTransparency() is a incorrect translation of the code for what it should be Block#isFullCube(). This should fix occlussion culling (as visibility data was being filled with data wrongly) and probably also lighting. Although I couldn't test it all because the game would crash for me in Linux (for unrelated reasons to the mod seemingly).