### PR TITLE
Fix Multidraw

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/sodium/client/gl/device/GLRenderDevice.java
+++ b/common/src/main/java/net/caffeinemc/mods/sodium/client/gl/device/GLRenderDevice.java
@@ -278,19 +278,12 @@ public class GLRenderDevice implements RenderDevice {
         public void multiDrawElementsBaseVertex(MultiDrawBatch batch, GlIndexType indexType) {
             GlPrimitiveType primitiveType = GLRenderDevice.this.activeTessellation.getPrimitiveType();
 
-            for (int i = 0; i < batch.size(); i++) {
-                int elementCount = MemoryUtil.memGetInt(batch.pElementCount + i * Integer.BYTES);
-                long elementPointer = MemoryUtil.memGetAddress(batch.pElementPointer + i * Long.BYTES);
-                int baseVertex = MemoryUtil.memGetInt(batch.pBaseVertex + i * Integer.BYTES);
-
-                GL32.glDrawElementsBaseVertex(
-                        primitiveType.getId(),
-                        elementCount,
-                        indexType.getFormatId(),
-                        elementPointer,
-                        baseVertex
-                );
-            }
+            GL32C.nglMultiDrawElementsBaseVertex(primitiveType.getId(),
+                    batch.pElementCount,
+                    indexType.getFormatId(),
+                    batch.pElementPointer,
+                    batch.size(),
+                    batch.pBaseVertex);
         }
 
         @Override


### PR DESCRIPTION
Until now multidraw couldn't be used because LWJGL didn't exposed glMultiDrawElementsBaseVertex, now that the project uses LWJGL 3 there isn't a need anymore of simulating it, this change should improve performance significantly, although I couldn't test it in production it should work just fine.