### PR TITLE
Add virtual cursor mixin and make the virtual cursor move like the real cursor

### DIFF
--- a/common/src/main/java/dev/vexor/radium/lwjgl3/implementation/glfw/VirtualGLFWMouseImplementation.java
+++ b/common/src/main/java/dev/vexor/radium/lwjgl3/implementation/glfw/VirtualGLFWMouseImplementation.java
@@ -76,9 +76,6 @@ public class VirtualGLFWMouseImplementation implements MouseImplementation {
     public void createMouse() {
         this.windowHandle = Display.getHandle();
 
-        if (GLFW.glfwRawMouseMotionSupported() && !Mouse.getPrivilegedBoolean("org.lwjgl.input.Mouse.disableRawInput"))
-            GLFW.glfwSetInputMode(this.windowHandle, GLFW.GLFW_RAW_MOUSE_MOTION, GLFW.GLFW_TRUE);
-
         this.buttonCallback = GLFWMouseButtonCallback.create((window, button, action, mods) -> {
             byte state = action == GLFW.GLFW_PRESS ? (byte) 1 : (byte) 0;
             putMouseEvent((byte) button, state, 0, System.nanoTime());

--- a/common/src/main/java/dev/vexor/radium/mixin/core/MixinMinecraftDrawVirtualCursor.java
+++ b/common/src/main/java/dev/vexor/radium/mixin/core/MixinMinecraftDrawVirtualCursor.java
@@ -1,4 +1,4 @@
-package dev.vexor.radium.lwjgl3.mixin;
+package dev.vexor.radium.mixin.core;
 
 import dev.vexor.radium.lwjgl3.implementation.glfw.VirtualGLFWMouseImplementation;
 import net.minecraft.client.MinecraftClient;

--- a/common/src/main/resources/radium.mixins.json
+++ b/common/src/main/resources/radium.mixins.json
@@ -6,6 +6,7 @@
   "compatibilityLevel": "JAVA_17",
   "client": [
     "core.MixinFramebuffer",
+    "core.MixinMinecraftDrawVirtualCursor",
     "core.MixinMinecraftFixEarlyCrashNoReports",
     "core.MixinScreenFixClipboard",
     "core.culling.BlockEntityRenderDispatcherMixin",


### PR DESCRIPTION
This PR adds the the virtual cursor mixin to the mixins.json file and removes the raw mouse input of the virtual cursor, to make it behave exactly like the system cursor.